### PR TITLE
Declare Kotlin version in Gradle build scripts

### DIFF
--- a/kapt-example-app/build.gradle.kts
+++ b/kapt-example-app/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    kotlin("jvm") version "1.1.3-2"
     kotlin("kapt")
     application
 }

--- a/kapt-example-core/build.gradle.kts
+++ b/kapt-example-core/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    kotlin("jvm") version "1.1.3-2"
 }
 
 dependencies {

--- a/kapt-example-processor/build.gradle.kts
+++ b/kapt-example-processor/build.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    kotlin("jvm")
+    kotlin("jvm") version "1.1.3-2"
     kotlin("kapt")
 }
 


### PR DESCRIPTION
Happy [Gradle 4.3 release](https://github.com/gradle/gradle/releases/tag/v4.3.0) day!

The Gradle team had to make a minor breaking change to the Kotlin DSL, but never fear as this automated pull request should fix the incompatibility by explicitly declaring the Kotlin JVM version in your Kotlin build scripts. See https://github.com/gradle/kotlin-dsl/releases/tag/v0.12.0.

Have a pleasant day! ☀️